### PR TITLE
Delete useless and buggy assert false at the protocol layer

### DIFF
--- a/sendmail/sendmail.ml
+++ b/sendmail/sendmail.ml
@@ -95,7 +95,10 @@ module Value = struct
       | Code, `PN_501 txts -> Return (501, txts)
       | Code, `PN_504 txts -> Return (504, txts)
       | Code, `PP_250 txts -> Return (250, txts)
-      | _, _ -> assert false in
+      | _, v ->
+        let code = Reply.code v in
+        let txts = Reply.lines v in
+        Error (`Unexpected_response (code, txts)) in
     let rec go = function
       | Decoder.Done v -> k v
       | Decoder.Read { buffer; off; len; continue; } ->

--- a/sendmail/sendmail_with_tls.ml
+++ b/sendmail/sendmail_with_tls.ml
@@ -121,7 +121,9 @@ module Value_without_tls = struct
         | Code, `PP_250 txts -> Return (250, txts)
         | _, _ ->
           Log.err (fun m -> m "Unexpected valid value: witness:%a value:%a" pp_witness w Reply.pp v) ;
-          assert false in
+          let code = Reply.code v in
+          let txts = Reply.lines v in
+          Error (`Unexpected_response (code, txts)) in
       let rec go = function
         | Decoder.Done v -> k v
         | Decoder.Read { buffer; off; len; continue; } ->

--- a/src/reply.mli
+++ b/src/reply.mli
@@ -45,6 +45,8 @@ val pp : t Fmt.t
 val compare : t -> t -> int
 val equal : t -> t -> bool
 val v : int -> string list -> t
+val code : t -> int
+val lines : t -> string list
 
 module Decoder : sig
   type error = [ `Invalid_code of int | Decoder.error ]


### PR DESCRIPTION
Instead to fail, we return an error when a server/client does not respond what we want.