### PR TITLE
Add support of 8BITMIME and check if the server has STARTTLS extension

### DIFF
--- a/sendmail/sendmail_with_tls.mli
+++ b/sendmail/sendmail_with_tls.mli
@@ -71,7 +71,7 @@ type ('a, 's) stream = ('a, 's) Sendmail.stream
 type error =
   [ Decoder.error
   | Decoder.error
-  | `Protocol of Sendmail.error
+  | `Protocol of [ Sendmail.error | `STARTTLS_unavailable ]
   | `Tls_alert of Tls.Packet.alert_type
   | `Tls_failure of Tls.Engine.failure ]
 


### PR DESCRIPTION
An other point, process described into `sendmail` and `sendmail-with-tls` is basically the same (the second add a STARTTLS command only). We should be able to functorize the process over a `Monad` and a `Context`.