### PR TITLE
Mix between polymorphic variants and functors about errors is bad

### DIFF
--- a/sendmail/sendmail.mli
+++ b/sendmail/sendmail.mli
@@ -16,9 +16,9 @@ type authentication =
 type ('a, 's) stream = unit -> ('a option, 's) io
 
 type error =
-  [ Request.Decoder.error
-  | Reply.Decoder.error
-  | `Unexpected_response of int * string list
+  [ `Error of [ Request.Encoder.error
+              | Reply.Decoder.error
+              | `Unexpected_response of int * string list ]
   | `Unsupported_mechanism
   | `Encryption_required
   | `Weak_mechanism

--- a/src/state.mli
+++ b/src/state.mli
@@ -45,19 +45,22 @@ module type C = sig
 end
 
 module Scheduler (Context : C) (Value : S with type encoder = Context.encoder and type decoder = Context.decoder) : sig
+  type error = [ `Error of Value.error ]
+
   val bind : ('a, 'err) t -> f:('a -> ('b, 'err) t) -> ('b, 'err) t
 
   val ( let* ) : ('a, 'err) t -> ('a -> ('b, 'err) t) -> ('b, 'err) t
   val ( >>= ) : ('a, 'err) t -> ('a -> ('b, 'err) t) -> ('b, 'err) t
 
-  val encode : Context.t -> 'a Value.send -> 'a -> (Context.t -> ('b, Value.error) t) -> ('b, Value.error) t
-  val decode : Context.t -> 'a Value.recv -> (Context.t -> 'a -> ('b, Value.error) t) -> ('b, Value.error) t
+  val encode : Context.t -> 'a Value.send -> 'a -> (Context.t -> ('b, [> error ] as 'err) t) -> ('b, 'err) t
+  val decode : Context.t -> 'a Value.recv -> (Context.t -> 'a -> ('b, [> error ] as 'err) t) -> ('b, 'err) t
 
-  val send : Context.t -> 'a Value.send -> 'a -> (unit, Value.error) t
-  val recv : Context.t -> 'a Value.recv -> ('a, Value.error) t
+  val send : Context.t -> 'a Value.send -> 'a -> (unit, [> error ]) t
+  val recv : Context.t -> 'a Value.recv -> ('a, [> error ]) t
 
   val return : 'v -> ('v, 'err) t
   val fail : 'err -> ('v, 'err) t
+  val reword_error : ('err0 -> 'err1) -> ('v, 'err0) t -> ('v, 'err1) t
 
   val error_msgf : ('a, Format.formatter, unit, ('b, [> Rresult.R.msg ]) t) format4 -> 'a
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -289,7 +289,7 @@ let test_replies_1 () =
 
 let () =
   Alcotest.run "colombe"
-    [ "requests", test_requests_0 ()
-    ; "requests", test_requests_1 ()
-    ; "replies", test_replies_0 ()
-    ; "replies", test_replies_1 () ]
+    [ "requests 0", test_requests_0 ()
+    ; "requests 1", test_requests_1 ()
+    ; "replies 0", test_replies_0 ()
+    ; "replies 1", test_replies_1 () ]

--- a/test/test_sendmail.ml
+++ b/test/test_sendmail.ml
@@ -251,7 +251,7 @@ let test_6 () =
       [ Rresult.R.get_ok @@ Colombe_emile.to_forward_path anil ]
       (fun () -> unix.return None) in
   match Unix_scheduler.prj fiber with
-  | Error (`Unexpected_response (550, _)) -> is_empty ()
+  | Error (`Error (`Unexpected_response (550, _))) -> is_empty ()
   | Error err -> Fmt.failwith "Got an error: %a" Sendmail.pp_error err
   | Ok _ -> Fmt.failwith "Unexpected valid result"
 


### PR DESCRIPTION
Functors and errors with polymorphic variants is so bad but we need to keep type equality mostly to be able to extend it with user-defined error (eg. `[ error ]` to `[> error ]`). This PR unlock this possibility at the first ground (eg. `State`). The result is quite noisy but, eh ...