### PR TITLE
Constraint sendmail to use >= base64.3.0.0

### DIFF
--- a/sendmail.opam
+++ b/sendmail.opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.8"}
   "colombe" {= version}
   "tls"
-  "base64"
+  "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
   "mrmime" {>= "0.2.0" & with-test}


### PR DESCRIPTION
Fix #21 