### PR TITLE
Handle the dot from the user input

### DIFF
--- a/sendmail.opam
+++ b/sendmail.opam
@@ -22,6 +22,6 @@ depends: [
   "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
-  "mrmime" {>= "0.2.0" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
   "alcotest" {with-test}
 ]

--- a/sendmail/sendmail.ml
+++ b/sendmail/sendmail.ml
@@ -233,7 +233,9 @@ let sendmail ({ bind; return; } as impl) rdwr flow context ?authentication ~doma
   (* assert that context is empty. *)
   let rec go = function
     | Some (buf, off, len) ->
-      rdwr.wr flow buf off len >>- mail >>- go
+       if len >= 1 && buf.[off] = '.'
+       then ( rdwr.wr flow "." 0 1 >>- fun () -> rdwr.wr flow buf off len >>- mail >>- go )
+       else rdwr.wr flow buf off len >>- mail >>- go
     | None -> return () in
   Log.debug (fun m -> m "Start to send email") ;
   mail () >>- go >>- fun () ->

--- a/sendmail/sendmail_lwt.mli
+++ b/sendmail/sendmail_lwt.mli
@@ -25,7 +25,7 @@ val sendmail :
 
     The connection already start a TLS connection to the peer. The peer is
    probably available on [*:465] (the default of [port] argument). The [mail]
-   stream {b must} emit for each chunk a CRLF at the end. As an user of GMail,
+   stream {b must} emit for each chunk a CRLF at the end (a line). As an user of GMail,
    the call of [sendmail] looks like:
 
     {[
@@ -65,8 +65,16 @@ let () = match Lwt_main.run (run ()) with
     [sendmail] does not strictly depend on [mrmime] or [emile]. However, we
    advise to use them to produce typed and well-formed mails. [sendmail] does
    not handle properly contents of mails as are. It just emits the stream to the
-   pipeline directly without any changes. Again, this job can be done by
-   [mrmime] - or yourself.
+   pipeline directly without any changes if the line does not start with a dot
+   (["."]). Otherwise, it prepends the line with a new dot (which has a
+   signification in terms of SMTP).
+
+    We assume that each call of [mail ()] gives to us a line - something which
+   ends up with CRLF (["\r\n"]). By this way, we can {i sanitize} the dot
+   character - and only on this way.
+
+    [mrmime] ensures to make on its way a stream which emits line per line. A
+   non-user of [mrmime] should be aware about this assumption.
 
     [sendmail] starts by itself a TLS connection with the SMTP server. *)
 

--- a/sendmail/sendmail_lwt.mli
+++ b/sendmail/sendmail_lwt.mli
@@ -89,4 +89,4 @@ val sendmail_with_starttls :
 
     The user should use the first one but in the context of the non-existence of it, the second one is
    available. Usage and arguments are the same. However, default value of [port] is the default value of
-   your operating system (see {Unix.getprotobyname}). *)
+   your operating system (see {!Unix.getprotobyname}). *)

--- a/sendmail/sendmail_with_starttls.ml
+++ b/sendmail/sendmail_with_starttls.ml
@@ -558,6 +558,8 @@ let run
       | Error err -> return (Error err : ('a, 'err) result) in
     go m
 
+let _dot = Cstruct.of_string "."
+
 let sendmail { bind; return } rdwr flow ctx mail =
   let ( >>= ) = bind in
 
@@ -574,7 +576,8 @@ let sendmail { bind; return } rdwr flow ctx mail =
       | None -> return state
       | Some (buf, off, len) ->
         let raw = Cstruct.of_string buf ~off ~len in
-        match Tls.Engine.send_application_data state [ raw ] with
+        let raw = if len >= 1 && buf.[off] = '.' then [ _dot; raw ] else [ raw ] in
+        match Tls.Engine.send_application_data state raw with
         | Some (state, raw) ->
           let buf = Cstruct.to_string raw in
           rdwr.wr flow buf 0 (Cstruct.len raw) >>= fun () -> go state

--- a/sendmail/sendmail_with_starttls.mli
+++ b/sendmail/sendmail_with_starttls.mli
@@ -100,7 +100,8 @@ val sendmail :
   reverse_path -> forward_path list ->
   ((string * int * int), 's) stream ->
   ((unit, error) result, 's) io
-(** [sendmail impl rdwr flow ctx tls_config ?authentication ~domain sender recipients mail] where:
+(** [sendmail impl rdwr flow ctx tls_config ?authentication ~domain sender
+   recipients mail] where:
 
     {ul
     {- [impl] is the scheduler (unix, lwt or async)}
@@ -113,6 +114,11 @@ val sendmail :
     {- [recipients] recipients of the mail}
     {- [mail] stream of the mail}}
 
-    This process try to send a mail according [RFC4409]. It ensures to use [STARTTLS] (eg. [RFC3207]) while the process
-    according TLS configuration [tls_config]. If [authentication] is given, it does the authentication
-    only while TLS flow. Mail is sended only while TLS flow. *)
+    This process try to send a mail according [RFC4409]. It ensures to use
+   [STARTTLS] (eg. [RFC3207]) while the process according TLS configuration
+   [tls_config]. If [authentication] is given, it does the authentication only
+   while TLS flow. Mail is sended only while TLS flow.
+
+    The stream [mail] must respects same assumptions as
+   {!Sendmail_lwt.sendmail}. *)
+


### PR DESCRIPTION
On top of mirage/pecu#6 and mirage/mrmime#38, this PR wants to fix #29. However, we strictly assume now that the email is emitted line per line. We handle only one (and I don't want to handle larger cases) case where the **line** starts with a dot. However, if the end-user sends (on the mail stream) multiple lines and one of them (like the second) starts with a dot, `colombe` **is not** able to correctly serialize this dot.

The update about `pecu` is to ensure that the `pecu`'s encoder emits line per line the content. `base64` should never emit a dot so it's not a problem. The last kind of encoding is the _raw_ encoding and only this specific stream (even if it was wrapped into `mrmime` email) shoud be well implemented.