### PR TITLE
Be resilient about bad base64 input from mailgun service

### DIFF
--- a/sendmail/sendmail_with_starttls.ml
+++ b/sendmail/sendmail_with_starttls.ml
@@ -599,10 +599,18 @@ let auth ctx mechanism info =
                 in
                 send ctx Value.Payload payload
             | x :: _ ->
-                let x = Base64.decode_exn x in
+            match Base64.decode x with
+            | Ok x ->
                 let payload =
                   Base64.encode_exn
                     (Fmt.strf "%s\000%s\000%s" x username password) in
+                send ctx Value.Payload payload
+            | Error _ ->
+                Log.warn (fun m ->
+                    m "The server send an invalid base64 value: %S" x) ;
+                let payload =
+                  Base64.encode_exn (Fmt.strf "\000%s\000%s" username password)
+                in
                 send ctx Value.Payload payload
           in
           recv ctx Value.Code >>= function

--- a/test/test_sendmail.ml
+++ b/test/test_sendmail.ml
@@ -453,6 +453,48 @@ let test_8 () =
   | Error err -> Fmt.failwith "Got an error: %a" Sendmail.pp_error err
   | Ok _ -> is_empty ()
 
+let test_9 () =
+  Alcotest.test_case "base64" `Quick @@ fun () ->
+  let ctx = Colombe.State.Context.make () in
+  let rdwr, is_empty =
+    rdwr_from_flows
+      [
+        "220 smtp.gmail.com ESTMP - gsmtp";
+        "250-smtp.gmail.com at your service, [8.8.8.8]";
+        "250-AUTH LOGIN PLAIN";
+        "250 8BITMIME";
+        "334 Go ahead";
+        "235 authenticated";
+        "250 <romain.calascibetta@gmail.com> as sender";
+        "250 <anil@recoil.org> as recipient";
+        "354 ";
+        "250 Sended!";
+        "221 Closing connection.";
+      ]
+      [
+        "EHLO gmail.com";
+        "AUTH PLAIN";
+        Base64.encode_exn ~pad:true (Fmt.strf "\000romain\000foobar");
+        "MAIL FROM:<romain.calascibetta@gmail.com> BODY=8BITMIME";
+        "RCPT TO:<anil@recoil.org>";
+        "DATA";
+        ".";
+        "QUIT";
+      ] in
+  let authentication =
+    { Sendmail.mechanism = PLAIN; username = "romain"; password = "foobar" }
+  in
+  let fiber =
+    Sendmail.sendmail unix rdwr () ctx
+      ~domain:(Colombe.Domain.Domain [ "gmail"; "com" ])
+      (Rresult.R.get_ok @@ Colombe_emile.to_reverse_path romain_calascibetta)
+      [ Rresult.R.get_ok @@ Colombe_emile.to_forward_path anil ]
+      ~authentication
+      (fun () -> unix.return None) in
+  match Unix_scheduler.prj fiber with
+  | Error err -> Fmt.failwith "Got an error: %a" Sendmail.pp_error err
+  | Ok _ -> is_empty ()
+
 let () =
   Alcotest.run "sendmail"
     [
@@ -467,5 +509,6 @@ let () =
           test_6 ();
           test_7 ();
           test_8 ();
+          test_9 ();
         ] );
     ]


### PR DESCRIPTION
Fix oxidizing/letters#35 (we diverge from the RFC 4954):
- [ ] add a regression test