### PR TITLE
Handle when the server close abruptly a connection

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.18.0
+version = 0.19.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters=no

--- a/sendmail/sendmail.ml
+++ b/sendmail/sendmail.ml
@@ -121,8 +121,7 @@ let run :
 
   let rec go = function
     | Read { buffer; off; len; k } ->
-        rdwr.rd flow buffer off len >>= fun v ->
-        go (k v)
+        rdwr.rd flow buffer off len >>= fun v -> go (k v)
     | Write { buffer; off; len; k } ->
         rdwr.wr flow buffer off len >>= fun () -> go (k len)
     | Return v -> return (Ok v)
@@ -131,9 +130,10 @@ let run :
 
 let properly_quit_and_fail ctx err =
   let open Monad in
-  reword_error (fun _ -> err) begin
-  send ctx Value.Quit () >>= fun () -> recv ctx Value.PP_221 >>= fun _ ->
-  fail err end
+  reword_error
+    (fun _ -> err)
+    ( send ctx Value.Quit () >>= fun () ->
+      recv ctx Value.PP_221 >>= fun _ -> fail err )
 
 let auth ctx mechanism info =
   let open Monad in
@@ -143,8 +143,7 @@ let auth ctx mechanism info =
   match mechanism with
   | Value.PLAIN -> (
       let* code, txts =
-        send ctx Value.Auth mechanism >>= fun () -> recv ctx Value.Code
-      in
+        send ctx Value.Auth mechanism >>= fun () -> recv ctx Value.Code in
       match code with
       | 504 -> properly_quit_and_fail ctx `Unsupported_mechanism
       | 538 -> properly_quit_and_fail ctx `Encryption_required
@@ -170,8 +169,7 @@ let auth ctx mechanism info =
                 let payload =
                   Base64.encode_exn (Fmt.strf "\000%s\000%s" username password)
                 in
-                send ctx Value.Payload payload
-          in
+                send ctx Value.Payload payload in
           recv ctx Value.Code >>= function
           | 235, _txts -> return `Authenticated
           | 501, _txts -> properly_quit_and_fail ctx `Authentication_rejected
@@ -238,8 +236,7 @@ let m0 ctx ?authentication ~domain sender recipients =
     else [] in
   let* code, txts =
     send ctx Value.Mail_from (sender, parameters) >>= fun () ->
-    recv ctx Value.Code
-  in
+    recv ctx Value.Code in
   let rec go = function
     | [] ->
         send ctx Value.Data () >>= fun () ->

--- a/sendmail/sendmail_lwt.ml
+++ b/sendmail/sendmail_lwt.ml
@@ -20,10 +20,10 @@ let rdwr =
     Sigs.rd =
       (fun { ic; _ } bytes off len ->
         let open Lwt.Infix in
-        Lwt_scheduler.inj begin
-        Lwt_io.read_into ic bytes off len >>= function
-        | 0 -> Lwt.return `End
-        | len -> Lwt.return (`Len len) end);
+        Lwt_scheduler.inj
+          (Lwt_io.read_into ic bytes off len >>= function
+           | 0 -> Lwt.return `End
+           | len -> Lwt.return (`Len len)));
     wr =
       (fun { oc; _ } bytes off len ->
         let res =

--- a/sendmail/sendmail_lwt.ml
+++ b/sendmail/sendmail_lwt.ml
@@ -19,8 +19,11 @@ let rdwr =
   {
     Sigs.rd =
       (fun { ic; _ } bytes off len ->
-        let res = Lwt_io.read_into ic bytes off len in
-        Lwt_scheduler.inj res);
+        let open Lwt.Infix in
+        Lwt_scheduler.inj begin
+        Lwt_io.read_into ic bytes off len >>= function
+        | 0 -> Lwt.return `End
+        | len -> Lwt.return (`Len len) end);
     wr =
       (fun { oc; _ } bytes off len ->
         let res =

--- a/sendmail/sendmail_with_starttls.ml
+++ b/sendmail/sendmail_with_starttls.ml
@@ -577,8 +577,9 @@ module Monad = State.Scheduler (Context_with_tls) (Value_with_tls)
 
 let properly_quit_and_fail ctx err =
   let open Monad in
+  reword_error (fun _ -> err) begin
   let* _txts = send ctx Value.Quit () >>= fun () -> recv ctx Value.PP_221 in
-  Error err
+  fail err end
 
 let auth ctx mechanism info =
   let open Monad in

--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -42,7 +42,7 @@ type ('v, 'err) state =
       buffer : Bytes.t;
       off : int;
       len : int;
-      continue : int -> ('v, 'err) state;
+      continue : [ `End | `Len of int ] -> ('v, 'err) state;
     }
   | Error of 'err info
 
@@ -152,12 +152,15 @@ let prompt :
             (* XXX(dinosaure): we make a new decoder here and we did __not__ set [decoder.max] owned by end-user,
                and this is exactly what we want. *)
     then
+      let continue = function
+        | `Len len -> go (off + len)
+        | `End -> Error { error= `End_of_input; buffer= decoder.buffer; committed= decoder.pos; } in
       Read
         {
           buffer = decoder.buffer;
           off;
           len = Bytes.length decoder.buffer - off;
-          continue = (fun len -> go (off + len));
+          continue;
         }
     else (
       decoder.max <- off ;

--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -154,7 +154,13 @@ let prompt :
     then
       let continue = function
         | `Len len -> go (off + len)
-        | `End -> Error { error= `End_of_input; buffer= decoder.buffer; committed= decoder.pos; } in
+        | `End ->
+            Error
+              {
+                error = `End_of_input;
+                buffer = decoder.buffer;
+                committed = decoder.pos;
+              } in
       Read
         {
           buffer = decoder.buffer;

--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -33,7 +33,7 @@ type ('v, 'err) state =
       buffer : bytes;
       off : int;
       len : int;
-      continue : int -> ('v, 'err) state;
+      continue : [ `Len of int | `End ] -> ('v, 'err) state;
     }
   | Error of 'err info
 

--- a/src/sigs.ml
+++ b/src/sigs.ml
@@ -12,7 +12,7 @@ type 't impl = {
 }
 
 type ('flow, 's) rdwr = {
-  rd : 'flow -> bytes -> int -> int -> (int, 's) io;
+  rd : 'flow -> bytes -> int -> int -> ([ `End | `Len of int ], 's) io;
   wr : 'flow -> string -> int -> int -> (unit, 's) io;
 }
 

--- a/src/sigs.mli
+++ b/src/sigs.mli
@@ -12,7 +12,7 @@ type 't impl = {
 }
 
 type ('flow, 's) rdwr = {
-  rd : 'flow -> bytes -> int -> int -> (int, 's) io;
+  rd : 'flow -> bytes -> int -> int -> ([ `End | `Len of int ], 's) io;
   wr : 'flow -> string -> int -> int -> (unit, 's) io;
 }
 

--- a/src/state.ml
+++ b/src/state.ml
@@ -1,7 +1,7 @@
 let ( <.> ) f g x = f (g x)
 
 type ('a, 'err) t =
-  | Read of { buffer : bytes; off : int; len : int; k : int -> ('a, 'err) t }
+  | Read of { buffer : bytes; off : int; len : int; k : [ `End | `Len of int ] -> ('a, 'err) t }
   | Write of { buffer : string; off : int; len : int; k : int -> ('a, 'err) t }
   | Return of 'a
   | Error of 'err
@@ -74,7 +74,14 @@ struct
   let rec go ~f m len =
     match m len with
     | Return v -> f v
-    | Read { k; off; len; buffer } -> Read { k = go ~f k; off; len; buffer }
+    | Read { k; off; len; buffer } ->
+      let rec k0 = function
+        | `End -> go ~f k1 0
+        | `Len len -> go ~f k1 len
+      and k1 = function
+        | 0 -> k `End
+        | len -> k (`Len len) in
+      Read { k= k0; off; len; buffer }
     | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
     | Error err -> Error err
 
@@ -83,7 +90,14 @@ struct
     match m with
     | Return v -> f v
     | Error err -> Error err
-    | Read { k; off; len; buffer } -> Read { k = go ~f k; off; len; buffer }
+    | Read { k; off; len; buffer } ->
+      let rec k0 = function
+        | `End -> go ~f k1 0
+        | `Len len -> go ~f k1 len
+      and k1 = function
+        | 0 -> k `End
+        | len -> k (`Len len) in
+      Read { k = k0; off; len; buffer }
     | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
 
   let ( let* ) m f = bind m ~f

--- a/src/state.ml
+++ b/src/state.ml
@@ -1,7 +1,12 @@
 let ( <.> ) f g x = f (g x)
 
 type ('a, 'err) t =
-  | Read of { buffer : bytes; off : int; len : int; k : [ `End | `Len of int ] -> ('a, 'err) t }
+  | Read of {
+      buffer : bytes;
+      off : int;
+      len : int;
+      k : [ `End | `Len of int ] -> ('a, 'err) t;
+    }
   | Write of { buffer : string; off : int; len : int; k : int -> ('a, 'err) t }
   | Return of 'a
   | Error of 'err
@@ -75,13 +80,9 @@ struct
     match m len with
     | Return v -> f v
     | Read { k; off; len; buffer } ->
-      let rec k0 = function
-        | `End -> go ~f k1 0
-        | `Len len -> go ~f k1 len
-      and k1 = function
-        | 0 -> k `End
-        | len -> k (`Len len) in
-      Read { k= k0; off; len; buffer }
+        let rec k0 = function `End -> go ~f k1 0 | `Len len -> go ~f k1 len
+        and k1 = function 0 -> k `End | len -> k (`Len len) in
+        Read { k = k0; off; len; buffer }
     | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
     | Error err -> Error err
 
@@ -91,13 +92,9 @@ struct
     | Return v -> f v
     | Error err -> Error err
     | Read { k; off; len; buffer } ->
-      let rec k0 = function
-        | `End -> go ~f k1 0
-        | `Len len -> go ~f k1 len
-      and k1 = function
-        | 0 -> k `End
-        | len -> k (`Len len) in
-      Read { k = k0; off; len; buffer }
+        let rec k0 = function `End -> go ~f k1 0 | `Len len -> go ~f k1 len
+        and k1 = function 0 -> k `End | len -> k (`Len len) in
+        Read { k = k0; off; len; buffer }
     | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
 
   let ( let* ) m f = bind m ~f

--- a/src/state.ml
+++ b/src/state.ml
@@ -79,11 +79,11 @@ struct
   let rec go ~f m len =
     match m len with
     | Return v -> f v
-    | Read { k; off; len; buffer } ->
-        let rec k0 = function `End -> go ~f k1 0 | `Len len -> go ~f k1 len
-        and k1 = function 0 -> k `End | len -> k (`Len len) in
-        Read { k = k0; off; len; buffer }
-    | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
+    | Read { k; off; len; buffer } -> Read { k = go ~f k; off; len; buffer }
+    | Write { k; off; len; buffer } ->
+        let k0 = function `End -> k 0 | `Len len -> k len in
+        let k1 = function 0 -> go ~f k0 `End | len -> go ~f k0 (`Len len) in
+        Write { k = k1; off; len; buffer }
     | Error err -> Error err
 
   let bind : ('a, 'err) t -> f:('a -> ('b, 'err) t) -> ('b, 'err) t =
@@ -91,11 +91,11 @@ struct
     match m with
     | Return v -> f v
     | Error err -> Error err
-    | Read { k; off; len; buffer } ->
-        let rec k0 = function `End -> go ~f k1 0 | `Len len -> go ~f k1 len
-        and k1 = function 0 -> k `End | len -> k (`Len len) in
-        Read { k = k0; off; len; buffer }
-    | Write { k; off; len; buffer } -> Write { k = go ~f k; off; len; buffer }
+    | Read { k; off; len; buffer } -> Read { k = go ~f k; off; len; buffer }
+    | Write { k; off; len; buffer } ->
+        let k0 = function `End -> k 0 | `Len len -> k len in
+        let k1 = function 0 -> go ~f k0 `End | len -> go ~f k0 (`Len len) in
+        Write { k = k1; off; len; buffer }
 
   let ( let* ) m f = bind m ~f
 

--- a/src/state.mli
+++ b/src/state.mli
@@ -1,5 +1,5 @@
 type ('a, 'err) t =
-  | Read of { buffer : bytes; off : int; len : int; k : int -> ('a, 'err) t }
+  | Read of { buffer : bytes; off : int; len : int; k : [ `End | `Len of int ] -> ('a, 'err) t }
   | Write of { buffer : string; off : int; len : int; k : int -> ('a, 'err) t }
   | Return of 'a
   | Error of 'err

--- a/src/state.mli
+++ b/src/state.mli
@@ -1,5 +1,10 @@
 type ('a, 'err) t =
-  | Read of { buffer : bytes; off : int; len : int; k : [ `End | `Len of int ] -> ('a, 'err) t }
+  | Read of {
+      buffer : bytes;
+      off : int;
+      len : int;
+      k : [ `End | `Len of int ] -> ('a, 'err) t;
+    }
   | Write of { buffer : string; off : int; len : int; k : int -> ('a, 'err) t }
   | Return of 'a
   | Error of 'err

--- a/test/test_sendmail.ml
+++ b/test/test_sendmail.ml
@@ -29,7 +29,7 @@ let rdwr_from_flows inputs outputs =
   let outputs = ref (List.map put_crlf outputs) in
   let read () bytes off len =
     match !inputs with
-    | [] -> Unix_scheduler.inj 0
+    | [] -> Unix_scheduler.inj `End
     | x :: r ->
         let len = min (String.length x) len in
         Bytes.blit_string x 0 bytes off len ;
@@ -37,7 +37,7 @@ let rdwr_from_flows inputs outputs =
         if len = String.length x
         then inputs := r
         else inputs := String.sub x len (String.length x - len) :: r ;
-        Unix_scheduler.inj len in
+        Unix_scheduler.inj (`Len len) in
   let rec write () bytes off len =
     match !outputs with
     | [] -> Fmt.failwith "Unexpected output: %S" (String.sub bytes off len)
@@ -211,7 +211,7 @@ let test_3 () =
 let test_4 () =
   Alcotest.test_case "authentication required" `Quick @@ fun () ->
   let ctx = Colombe.State.Context.make () in
-  let rdwr, is_empty =
+  let rdwr, _is_empty =
     rdwr_from_flows
       [
         "220 smtp.gmail.com ESMTP - gsmtp";
@@ -230,7 +230,6 @@ let test_4 () =
       (fun () -> unix.return None) in
   match Unix_scheduler.prj fiber with
   | Error err ->
-      is_empty () ;
       assert (`Authentication_required = err)
   | Ok _ -> Fmt.failwith "Should fail with [Encryption_required]"
 
@@ -495,6 +494,44 @@ let test_9 () =
   | Error err -> Fmt.failwith "Got an error: %a" Sendmail.pp_error err
   | Ok _ -> is_empty ()
 
+let test_10 () =
+  Alcotest.test_case "unproperly quit" `Quick @@ fun () ->
+  let ctx = Colombe.State.Context.make () in
+  let rdwr, is_empty =
+    rdwr_from_flows
+      [
+        "220 smtp.gmail.com ESMTP - gsmtp";
+        "250-smtp.gmail.com at your service, [8.8.8.8]";
+        "250-SIZE 0";
+        "250-AUTH LOGIN PLAIN";
+        "250-ENHANCEDSTATUSCODES";
+        "250 CHUNKING";
+        "334 ";
+        "501 Authentication rejected!";
+      ]
+      [
+        "EHLO gmail.com";
+        "AUTH PLAIN";
+        Base64.encode_exn ~pad:true (Fmt.strf "\000romain\000foobar");
+        "QUIT";
+      ] in
+  let authentication =
+    { Sendmail.mechanism = PLAIN; username = "romain"; password = "foobar" }
+  in
+  let fiber =
+    Sendmail.sendmail unix rdwr () ctx
+      ~domain:(Colombe.Domain.Domain [ "gmail"; "com" ])
+      (Rresult.R.get_ok @@ Colombe_emile.to_reverse_path romain_calascibetta)
+      [ Rresult.R.get_ok @@ Colombe_emile.to_forward_path anil ]
+      ~authentication
+      (fun () -> unix.return None) in
+  match Unix_scheduler.prj fiber with
+  | Error err ->
+      is_empty () ;
+      Fmt.epr ">>> %a.\n%!" Sendmail.pp_error err ;
+      assert (err = `Authentication_rejected)
+  | Ok _ -> Fmt.failwith "Should fail with [Authentication_rejected]"
+
 let () =
   Alcotest.run "sendmail"
     [
@@ -510,5 +547,6 @@ let () =
           test_7 ();
           test_8 ();
           test_9 ();
+          test_10 ();
         ] );
     ]

--- a/test/test_sendmail.ml
+++ b/test/test_sendmail.ml
@@ -229,8 +229,7 @@ let test_4 () =
       [ Rresult.R.get_ok @@ Colombe_emile.to_forward_path anil ]
       (fun () -> unix.return None) in
   match Unix_scheduler.prj fiber with
-  | Error err ->
-      assert (`Authentication_required = err)
+  | Error err -> assert (`Authentication_required = err)
   | Ok _ -> Fmt.failwith "Should fail with [Encryption_required]"
 
 let test_5 () =


### PR DESCRIPTION
This patch is a bit big but I think about such improvement a long time ago when with the current interface, it's not possible to emit the end of flow or distinct when the connection still alive (but we got nothing) or when the connection was reset by peer. This patch allows us to emit `[ Len of int | End ]` to the reader.

Then, a simple `reword_error` is enough to keep the initial error (like the rejected authentication) and a possible `End_of_input` error when we try to properly close the connection with `QUIT`. This PR wants to fix #46.